### PR TITLE
Fix registry URL for bower entries

### DIFF
--- a/app/models/catalog/bower_package.rb
+++ b/app/models/catalog/bower_package.rb
@@ -60,7 +60,7 @@ module Catalog
     end
 
     def bower_git_repo(name)
-      package = JSON.load(open("http://bower.herokuapp.com/packages/#{name}"))
+      package = JSON.load(open("https://registry.bower.io/packages/#{name}"))
       if package.is_a?(Hash)
         package['url']
       end


### PR DESCRIPTION
Old registry causes `HTTP 308` errors in running and prevents bootstrapping of new instances.